### PR TITLE
invalidate cloudfront cache entries as part of codebuild post_build p…

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,10 +3,8 @@ version: 0.2
 env:
   variables:
     CI: "true"
-#   parameter-store:
-#     key: "value"
-#     key: "value"
-            
+  parameter-store:
+    DISTRIBUTION_ID: "/Prod/CodeBuild/shanedg.com/Cloudfront_Distribution_ID"
 phases:
   install:
     commands:
@@ -18,6 +16,9 @@ phases:
   build:
     commands:
       - yarn build
+  post_build:
+    commands:
+      - aws cloudfront create-invalidation --distribution-id "${DISTRIBUTION_ID}" --paths "/*"
 artifacts:
   files:
     - '**/*'


### PR DESCRIPTION
…hase

# exciting
* use parameter_store from aws systems manager to securely store cloudfront distribution id for use in codebuild post_build phase cli command to create a new invalidation (clear cache)
* currently clearing entire cache, probably overkill TODO