### PR TITLE
update preconnect strategy

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,12 +12,16 @@
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
     <title>shane garrity | www.shanedg.com</title>
     <meta name="description" content="this is my website">
-    <link href="https://fonts.googleapis.com/css?family=Share+Tech+Mono" rel="stylesheet">
-
+    
+    <!-- Preconnect 3rd party domains, google tag manager, google fonts, iubenda -->
+    <link rel="preconnect" href="https://www.googletagmanager.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link rel="preconnect" href="https://cdn.iubenda.com">
     <!-- Preload 3rd party script, iubenda generated privacy policy -->
     <link rel="preload" as="script" href="https://cdn.iubenda.com/iubenda.js">
-    <!-- Preconnect 3rd party script, google tag manager -->
-    <link rel="preconnect" href="https://www.googletagmanager.com">
+
+    <!-- Google font -->
+    <link href="https://fonts.googleapis.com/css?family=Share+Tech+Mono" rel="stylesheet">
 
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':


### PR DESCRIPTION
+ include google fonts domain, `fonts.gstatic.com`
+ include iubenda cdn, `cdn.iubenda.com`; this one might be unnecessary because we're preloading the iubenda js snippet, so connection should already be established for the css file and the gif that the script pulls down