### PR TITLE
resolve test dependency hidden until now by setTimeout wrapper

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -2,8 +2,42 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 
-it('renders without crashing', () => {
+it('renders without crashing (initial, no consent)', () => {
   const div = document.createElement('div');
-  ReactDOM.render(<App />, div);
+  const consent = {
+    alreadyAsked: false,
+    consentGranted: false
+  };
+  ReactDOM.render(<App consent={consent} />, div);
+  ReactDOM.unmountComponentAtNode(div);
+});
+
+it('renders without crashing (consent denied)', () => {
+  const div = document.createElement('div');
+  const consent = {
+    alreadyAsked: true,
+    consentGranted: false
+  };
+  ReactDOM.render(<App consent={consent} />, div);
+  ReactDOM.unmountComponentAtNode(div);
+});
+
+it('renders without crashing (consent granted)', () => {
+  const div = document.createElement('div');
+  const consent = {
+    alreadyAsked: true,
+    consentGranted: true
+  };
+  ReactDOM.render(<App consent={consent} />, div);
+  ReactDOM.unmountComponentAtNode(div);
+});
+
+it('renders without crashing (BAD STATE)', () => {
+  const div = document.createElement('div');
+  const consent = {
+    alreadyAsked: false,
+    consentGranted: true
+  };
+  ReactDOM.render(<App consent={consent} />, div);
   ReactDOM.unmountComponentAtNode(div);
 });

--- a/src/components/Preferences/Preferences.test.js
+++ b/src/components/Preferences/Preferences.test.js
@@ -31,3 +31,13 @@ it('renders without crashing (consent granted)', () => {
   ReactDOM.render(<Preferences consent={consent} />, div);
   ReactDOM.unmountComponentAtNode(div);
 });
+
+it('renders without crashing (BAD STATE)', () => {
+  const div = document.createElement('div');
+  const consent = {
+    alreadyAsked: false,
+    consentGranted: true
+  };
+  ReactDOM.render(<Preferences consent={consent} />, div);
+  ReactDOM.unmountComponentAtNode(div);
+});


### PR DESCRIPTION
Resolves #44 

setTimeout was wrapping a reference to the `consent` prop object which was error'ing out silently up until setTimeout was removed in pull #43 